### PR TITLE
jsonpickle compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then conda install unittest2 --yes; fi
   - if [[ $TRAVIS_PYTHON_VERSION -ne "3.5" ]]; then conda install simplejson --yes ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then conda install pytables=3.2.0 --yes ; else conda install pytables=3.3.0 --yes ; fi
-  - pip install jsonpickle==0.7.2
+  - pip install jsonpickle
   - pip install -r requirements.txt
   - pip install .
 

--- a/neuroml/writers.py
+++ b/neuroml/writers.py
@@ -110,6 +110,12 @@ class JSONWriter(object):
     def __encode_as_json(cls,neuroml_document):
         neuroml_document = cls.__sanitize_doc(neuroml_document)
         from jsonpickle import encode as json_encode
+        try:
+            # Enable encoding of numpy arrays with recent jsonpickle versions
+            import jsonpickle.ext.numpy as jsonpickle_numpy
+            jsonpickle_numpy.register_handlers()
+        except ImportError:
+            pass  # older version of jsonpickle
         encoded = json_encode(neuroml_document)
         return encoded
     


### PR DESCRIPTION
libneuroML does not currently work correctly with recent `jsonpickle`, that's why `travis.yml` tests against `jsonpickle==0.7.2`. The reason seems to be that it encodes `numpy` arrays, but does not activate the `numpy` extension added in recent versions. The extension is mentioned in `jsonpickle`'s readme:
> jsonpickle includes a built-in numpy extension. If would like to encode sklearn models, numpy arrays, and other numpy-based data then you must enable the numpy extension by registering its handlers:
```pycon
>>> import jsonpickle.ext.numpy as jsonpickle_numpy
>>> jsonpickle_numpy.register_handlers()
```
When adding this, tests seem to work fine (but I did not test it more thoroughly than that).

BTW: It seems that the version is regularly updated in the development branch -- any reason to not do the releases on pypi as well? This is what we'd need for a conda package.