### PR TITLE
Allow loader to accept non-strings

### DIFF
--- a/neuroml/nml/nml.py
+++ b/neuroml/nml/nml.py
@@ -31,12 +31,9 @@ try:
 except ImportError:
     from xml.etree import ElementTree as etree_
 
+from six import string_types
 
 Validate_simpletypes_ = True
-if sys.version_info[0] == 2:
-    BaseStrType_ = basestring
-else:
-    BaseStrType_ = str
 
 
 def parsexml_(infile, parser=None, **kwargs):
@@ -473,7 +470,7 @@ def quote_xml(inStr):
     "Escape markup chars, but do not modify CDATA sections."
     if not inStr:
         return ''
-    s1 = (isinstance(inStr, BaseStrType_) and inStr or '%s' % inStr)
+    s1 = (isinstance(inStr, string_types) and inStr or '%s' % inStr)
     s2 = ''
     pos = 0
     matchobjects = CDATA_pattern_.finditer(s1)
@@ -495,7 +492,7 @@ def quote_xml_aux(inStr):
 
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, BaseStrType_) and inStr or '%s' % inStr)
+    s1 = (isinstance(inStr, string_types) and inStr or '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
     s1 = s1.replace('>', '&gt;')

--- a/neuroml/nml/nml.py
+++ b/neuroml/nml/nml.py
@@ -45,6 +45,11 @@ def parsexml_(infile, parser=None, **kwargs):
         except AttributeError:
             # fallback to xml.etree
             parser = etree_.XMLParser()
+
+    if not isinstance(infile, string_types):
+        # handle e.g. pathlib.Path
+        infile = str(infile)
+
     doc = etree_.parse(infile, parser=parser, **kwargs)
     return doc
 

--- a/neuroml/test/test_loaders.py
+++ b/neuroml/test/test_loaders.py
@@ -12,15 +12,30 @@ try:
 except ImportError:
     import unittest
 
+try:
+    import pathlib
+except ImportError:
+    pathlib = False
+
+
 class TestNeuroMLLoader(unittest.TestCase):
-    def test_load_neuroml(self):
+    def setUp(self):
         root_dir = os.path.dirname(neuroml.__file__)
         print('root dir is:')
         print(root_dir)
-        test_file_path = os.path.join(root_dir,'examples/test_files/Purk2M9s.nml')
+        self.test_file_path = os.path.join(root_dir, 'examples/test_files/Purk2M9s.nml')
+
+    def check_can_load_nml(self, test_file_path):
         print('test file path is:')
         print(test_file_path)
-        f = open(test_file_path,'r')
-        #print(f.read())
+        # f = open(test_file_path, 'r'):
+        # print(f.read())
         doc = loaders.NeuroMLLoader.load(test_file_path)
-        self.assertEqual(doc.id,'Purk2M9s')
+        self.assertEqual(doc.id, 'Purk2M9s')
+
+    def test_load_neuroml_str_path(self):
+        self.check_can_load_nml(self.test_file_path)
+
+    @unittest.skipUnless(pathlib, "requires pathlib (>py3.4)")
+    def test_load_neuroml_pathlib(self):
+        self.check_can_load_nml(pathlib.Path(self.test_file_path))

--- a/neuroml/writers.py
+++ b/neuroml/writers.py
@@ -1,4 +1,5 @@
 import neuroml
+from six import string_types
 
 
 class NeuroMLWriter(object):
@@ -10,7 +11,7 @@ class NeuroMLWriter(object):
         via chain of responsibility pattern.
         """
 
-        if isinstance(file,str) or isinstance(file,unicode):
+        if isinstance(file, string_types):
             file = open(file,'w')
 
         #TODO: this should be extracted from the schema:
@@ -137,15 +138,15 @@ class JSONWriter(object):
         return neuroml_document
 
     @classmethod
-    def __file_handle(file):
-        if isinstance(cls,file,str) or isinstance(cls,file,unicode):
+    def __file_handle(cls, filepath):
+        if isinstance(filepath, string_types):
             import tables
             fileh = tables.open_file(filepath, mode = "w")
 
             
     @classmethod    
     def write(cls,neuroml_document,file):
-        if isinstance(file,str) or isinstance(file,unicode):
+        if isinstance(file,string_types):
             fileh = open(file, mode = 'w')
         else:
             fileh = file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+six
 lxml

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email = "vellamike@gmail.com, p.gleeson@gmail.com",
     description = "A Python library for working with NeuroML descriptions of neuronal models",
     long_description = long_description,
-    install_requires=['lxml'],
+    install_requires=['lxml', 'six'],
     license = "BSD",
     url="http://libneuroml.readthedocs.org/en/latest/",
     classifiers = [


### PR DESCRIPTION
etree is old and so doesn't accept py3.4's `pathlib.Path`.
parsexml_ now calls `str()` on non-strings to work around this and other
similar `os.PathLike`s.