### PR TITLE
Fix unicode

### DIFF
--- a/neuroml/nml/nml.py
+++ b/neuroml/nml/nml.py
@@ -31,12 +31,9 @@ try:
 except ImportError:
     from xml.etree import ElementTree as etree_
 
+from six import string_types
 
 Validate_simpletypes_ = True
-if sys.version_info[0] == 2:
-    BaseStrType_ = basestring
-else:
-    BaseStrType_ = str
 
 
 def parsexml_(infile, parser=None, **kwargs):
@@ -473,7 +470,7 @@ def quote_xml(inStr):
     "Escape markup chars, but do not modify CDATA sections."
     if not inStr:
         return ''
-    s1 = (isinstance(inStr, BaseStrType_) and inStr or '%s' % inStr)
+    s1 = (isinstance(inStr, string_types) and inStr or '%s' % inStr)
     s2 = ''
     pos = 0
     matchobjects = CDATA_pattern_.finditer(s1)
@@ -495,7 +492,7 @@ def quote_xml_aux(inStr):
 
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, BaseStrType_) and inStr or '%s' % inStr)
+    s1 = (isinstance(inStr, string_types) and inStr or '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
     s1 = s1.replace('>', '&gt;')

--- a/neuroml/writers.py
+++ b/neuroml/writers.py
@@ -1,4 +1,5 @@
 import neuroml
+from six import string_types
 
 
 class NeuroMLWriter(object):
@@ -10,7 +11,7 @@ class NeuroMLWriter(object):
         via chain of responsibility pattern.
         """
 
-        if isinstance(file,str) or isinstance(file,unicode):
+        if isinstance(file, string_types):
             file = open(file,'w')
 
         #TODO: this should be extracted from the schema:
@@ -137,15 +138,15 @@ class JSONWriter(object):
         return neuroml_document
 
     @classmethod
-    def __file_handle(file):
-        if isinstance(cls,file,str) or isinstance(cls,file,unicode):
+    def __file_handle(cls, filepath):
+        if isinstance(filepath, string_types):
             import tables
             fileh = tables.open_file(filepath, mode = "w")
 
             
     @classmethod    
     def write(cls,neuroml_document,file):
-        if isinstance(file,str) or isinstance(file,unicode):
+        if isinstance(file,string_types):
             fileh = open(file, mode = 'w')
         else:
             fileh = file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+six
 lxml

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email = "vellamike@gmail.com, p.gleeson@gmail.com",
     description = "A Python library for working with NeuroML descriptions of neuronal models",
     long_description = long_description,
-    install_requires=['lxml'],
+    install_requires=['lxml', 'six'],
     license = "BSD",
     url="http://libneuroml.readthedocs.org/en/latest/",
     classifiers = [


### PR DESCRIPTION
The build was failing in 3.5 due to some explicit references to `unicode`. These were in type checks, and I've replaced them with `six.string_types`, which is probably the most correct way to do it.