### PR TITLE
Fix/info get all members

### DIFF
--- a/neuroml/nml/generatedssupersuper.py
+++ b/neuroml/nml/generatedssupersuper.py
@@ -205,7 +205,8 @@ class GeneratedsSuperSuper(object):
 
         info_str += "Please see the NeuroML standard schema documentation at https://docs.neuroml.org/Userdocs/NeuroMLv2.html for more information.\n\n"
         info_str += "Valid members for {} are:\n".format(self.__class__.__name__)
-        for member in self.member_data_items_:
+        all_members = self.get_members()
+        for member in all_members:
             info_str += "* {} (class: {}, {})\n".format(
                 member.get_name(),
                 member.get_data_type(),

--- a/neuroml/nml/nml.py
+++ b/neuroml/nml/nml.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Sep  2 12:29:38 2022 by generateDS.py version 2.40.13.
+# Generated Mon Sep  5 11:38:08 2022 by generateDS.py version 2.40.13.
 # Python 3.10.6 (main, Aug  2 2022, 00:00:00) [GCC 12.1.1 20220507 (Red Hat 12.1.1-1)]
 #
 # Command line options:

--- a/neuroml/test/test_nml.py
+++ b/neuroml/test/test_nml.py
@@ -59,10 +59,7 @@ class TestNML(unittest.TestCase):
         self.assertIsNone(doc.add(cell))
 
         # Already added, so throw exception
-        if int(platform.python_version_tuple()[0]) > 2:
-            with self.assertWarns(UserWarning):
-                doc.add(cell)
-        else:
+        with self.assertWarns(UserWarning):
             doc.add(cell)
 
         # Success
@@ -152,10 +149,7 @@ class TestNML(unittest.TestCase):
         pop3 = neuroml.Population(id="unique")
         network.add(pop3)
         # warning because this is already added
-        if int(platform.python_version_tuple()[0]) > 2:
-            with self.assertWarns(UserWarning):
-                network.add(pop3)
-        else:
+        with self.assertWarns(UserWarning):
             network.add(pop3)
 
         # Note that for Python, this is a new object

--- a/neuroml/test/test_nml.py
+++ b/neuroml/test/test_nml.py
@@ -37,6 +37,16 @@ class TestNML(unittest.TestCase):
         # Not in here:
         self.assertNotIn("cell", member_names)
 
+        # check with IonChannel: inherits from IonChannel
+        ionchannelhh = neuroml.IonChannelHH()
+        ion_members = ionchannelhh.get_members()
+        member_names = []
+        for m in ion_members:
+            member_names.append(m.get_name())
+        self.assertIn("conductance", member_names)
+        self.assertIn("gates", member_names)
+        self.assertIn("gate_hh_rates", member_names)
+
     def test_generic_add_single(self):
         """Test the generic add function for single addition."""
         doc = neuroml.NeuroMLDocument(id="testdoc")
@@ -157,10 +167,16 @@ class TestNML(unittest.TestCase):
         """Test getting member info."""
         cell = neuroml.Cell(id="testcell")
         info = cell.info()
-        if int(platform.python_version_tuple()[0]) > 2:
-            self.assertRegex(info, "morphology")
-            self.assertRegex(info, "biophysical_properties")
-            self.assertNotRegex(info, "network")
+        self.assertRegex(info, "morphology")
+        self.assertRegex(info, "biophysical_properties")
+        self.assertNotRegex(info, "network")
+
+        # check with IonChannel: inherits from IonChannel
+        ionchannelhh = neuroml.IonChannelHH()
+        info = ionchannelhh.info(return_format="list")
+        self.assertIn("conductance", info)
+        self.assertIn("gates", info)
+        self.assertIn("gate_hh_rates", info)
 
     def test_get_by_id(self):
         """Test the get_by_id method"""


### PR DESCRIPTION
@irahulsonkar: fixes the `info` method not showing bits for `ionChannelHH`. Was a minor issue---I forgot to use `get_members` in `info`, even though I did use it in `add`.

I'll merge this to dev as soon as CI passes.