### PR TITLE
NEURON compatible morphologies from ArrayMorphology.

### DIFF
--- a/neuroml/arraymorph.py
+++ b/neuroml/arraymorph.py
@@ -5,7 +5,6 @@ Prototype for object model backend for the libNeuroML project
 
 import numpy as np
 import neuroml
-from __future__ import print_function  # type: ignore
 
 
 neuro_lex_ids = {
@@ -27,7 +26,7 @@ def get_seg_group_by_id(sg_id, morph):
 
     """
     if not sg_id or not morph:
-        print_function("Please specify both a segment group id and a Morphology")
+        print("Please specify both a segment group id and a Morphology")
         return None
 
     for sg in morph.segment_groups:

--- a/neuroml/arraymorph.py
+++ b/neuroml/arraymorph.py
@@ -5,7 +5,7 @@ Prototype for object model backend for the libNeuroML project
 
 import numpy as np
 import neuroml
-from pyneuroml.pynml import print_function  # type: ignore
+from __future__ import print_function  # type: ignore
 
 
 neuro_lex_ids = {

--- a/neuroml/loaders.py
+++ b/neuroml/loaders.py
@@ -25,8 +25,8 @@ def print_(text, verbose=True):
 
 class NeuroMLLoader(object):
     @classmethod
-    def load(cls, src):
-        doc = cls.__nml2_doc(src)
+    def load(cls, src, silence=True):
+        doc = cls.__nml2_doc(src, silence)
         if isinstance(doc, neuroml.nml.nml.NeuroMLDocument):
             return doc
         else:
@@ -37,12 +37,13 @@ class NeuroMLLoader(object):
             )
 
     @classmethod
-    def __nml2_doc(cls, file_name):
+    def __nml2_doc(cls, file_name, silence=True):
+
         try:
 
             if supressGeneratedsWarnings:
                 warnings.simplefilter("ignore")
-            nml2_doc = nmlparse(file_name, silence=True)
+            nml2_doc = nmlparse(file_name, silence=silence)
             if supressGeneratedsWarnings:
                 warnings.resetwarnings()
         except Exception as e:
@@ -97,7 +98,7 @@ class SWCLoader(object):
     """
 
     @classmethod
-    def load_swc_single(cls, src, name=None):
+    def load_swc_single(cls, src, id=None):
 
         import numpy as np
         from neuroml import arraymorph
@@ -147,7 +148,7 @@ class SWCLoader(object):
             vertices=vertices,
             connectivity=connection_indices,
             node_types=section_types,
-            name=name,
+            id=id,
         )
 
 


### PR DESCRIPTION
Allows to do something like 

```
fname = 'Morphologies/pyr/MouseLight_Final/CNG version/AA0995.CNG.swc'
SWCLoader.load_swc_single(fname).to_neuroml_morphology("pyr_morph")   
```

and use successfully this morphology in NEURON simulations. Tested with https://neuromorpho.org/neuron_info.jsp?neuron_name=AA0995 . If you like it you can merge it; if you'd prefer not to merge right away, you can wait. I'll continue to use this code with other morphologies for a project of mine so I'll push fixes if this does not work with other morphologies.

I attached the generated morphology, for reference. The biophys is rubbish (they are the same as for the tutorial on the OLM  cell), but the morphology seems reasonable to me.

[pyr.cell.nml.zip](https://github.com/NeuralEnsemble/libNeuroML/files/9789164/pyr.cell.nml.zip)

