### PR TITLE
feat!(loaders): remove deprecated SWCLoader class

### DIFF
--- a/neuroml/loaders.py
+++ b/neuroml/loaders.py
@@ -91,6 +91,66 @@ class NeuroMLHdf5Loader(object):
             return nml2_doc
 
 
+class SWCLoader(object):
+    """
+    WARNING: Class defunct
+    """
+
+    @classmethod
+    def load_swc_single(cls, src, name=None):
+
+        import numpy as np
+        from neuroml import arraymorph
+
+        dtype = {
+            "names": ("id", "type", "x", "y", "z", "r", "pid"),
+            "formats": ("int32", "int32", "f4", "f4", "f4", "f4", "int32"),
+        }
+
+        d = np.loadtxt(src, dtype=dtype)
+
+        if len(np.nonzero(d["pid"] == -1)) != 1:
+            assert False, "Unexpected number of id's of -1 in file"
+
+        num_nodes = len(d["pid"])
+
+        root_index = np.where(d["pid"] == -1)[0][0]
+
+        # We might not nessesarily have continuous indices in the
+        # SWC file, so lets convert them:
+        index_to_id = d["id"]
+        id_to_index_dict = dict([(id, index) for index, id in enumerate(index_to_id)])
+
+        if len(id_to_index_dict) != len(index_to_id):
+            s = "Internal Error Loading SWC: Index and ID map are different lengths."
+            s += " [ID:%d, Index:%d]" % (len(index_to_id), len(id_to_index_dict))
+            # TODO: this is undefined!!
+            raise MorphologyImportError(s)  # noqa: F821
+
+        # Vertices and section types are easy:
+        vertices = d[["x", "y", "z", "r"]]
+        vertices = np.vstack([d["x"], d["y"], d["z"], d["r"]]).T
+        section_types = [swctype for ID, swctype in d[["id", "type"]]]
+
+        # for connection indices we want the root to have index -1:
+        connection_indices = np.zeros(num_nodes, dtype="int32")
+        for i in range(num_nodes):
+            pID = d["pid"][i]
+            if pID != -1:
+                parent_index = id_to_index_dict[pID]
+                connection_indices[i] = parent_index
+            else:
+                connection_indices[i] = -1
+
+        # This needs to become an "Optimized Morphology" of some kind
+        return arraymorph.ArrayMorphology(
+            vertices=vertices,
+            connectivity=connection_indices,
+            node_types=section_types,
+            name=name,
+        )
+
+
 class ArrayMorphLoader(object):
     @classmethod
     def __extract_morphology(cls, node):

--- a/neuroml/loaders.py
+++ b/neuroml/loaders.py
@@ -91,66 +91,6 @@ class NeuroMLHdf5Loader(object):
             return nml2_doc
 
 
-class SWCLoader(object):
-    """
-    WARNING: Class defunct
-    """
-
-    @classmethod
-    def load_swc_single(cls, src, name=None):
-
-        import numpy as np
-        from neuroml import arraymorph
-
-        dtype = {
-            "names": ("id", "type", "x", "y", "z", "r", "pid"),
-            "formats": ("int32", "int32", "f4", "f4", "f4", "f4", "int32"),
-        }
-
-        d = np.loadtxt(src, dtype=dtype)
-
-        if len(np.nonzero(d["pid"] == -1)) != 1:
-            assert False, "Unexpected number of id's of -1 in file"
-
-        num_nodes = len(d["pid"])
-
-        root_index = np.where(d["pid"] == -1)[0][0]
-
-        # We might not nessesarily have continuous indices in the
-        # SWC file, so lets convert them:
-        index_to_id = d["id"]
-        id_to_index_dict = dict([(id, index) for index, id in enumerate(index_to_id)])
-
-        if len(id_to_index_dict) != len(index_to_id):
-            s = "Internal Error Loading SWC: Index and ID map are different lengths."
-            s += " [ID:%d, Index:%d]" % (len(index_to_id), len(id_to_index_dict))
-            # TODO: this is undefined!!
-            raise MorphologyImportError(s)  # noqa: F821
-
-        # Vertices and section types are easy:
-        vertices = d[["x", "y", "z", "r"]]
-        vertices = np.vstack([d["x"], d["y"], d["z"], d["r"]]).T
-        section_types = [swctype for ID, swctype in d[["id", "type"]]]
-
-        # for connection indices we want the root to have index -1:
-        connection_indices = np.zeros(num_nodes, dtype="int32")
-        for i in range(num_nodes):
-            pID = d["pid"][i]
-            if pID != -1:
-                parent_index = id_to_index_dict[pID]
-                connection_indices[i] = parent_index
-            else:
-                connection_indices[i] = -1
-
-        # This needs to become an "Optimized Morphology" of some kind
-        return arraymorph.ArrayMorphology(
-            vertices=vertices,
-            connectivity=connection_indices,
-            node_types=section_types,
-            name=name,
-        )
-
-
 class ArrayMorphLoader(object):
     @classmethod
     def __extract_morphology(cls, node):

--- a/neuroml/loaders.py
+++ b/neuroml/loaders.py
@@ -93,11 +93,17 @@ class NeuroMLHdf5Loader(object):
 
 class SWCLoader(object):
     """
-    WARNING: Class defunct
+    This class is deprecated. Please refer to
+    https://docs.neuroml.org/Userdocs/ImportingMorphologyFiles.html
+    for information on importing/converting morphology files to NeuroML2.
     """
 
     @classmethod
     def load_swc_single(cls, src, name=None):
+
+        raise RuntimeError(
+            "This method/class is deprecated. Please see https://docs.neuroml.org/Userdocs/ImportingMorphologyFiles.html",
+        )
 
         import numpy as np
         from neuroml import arraymorph


### PR DESCRIPTION
It was marked as defunct long ago but remained in the sources. Removing this now to prevent users from using it

BREAKING CHANGE: removes defunct SWCLoader class.