### PR TITLE
fix(loaders): do not empty list of includes even if `include_includes…

### DIFF
--- a/neuroml/loaders.py
+++ b/neuroml/loaders.py
@@ -380,12 +380,10 @@ def _read_neuroml2(
     else:
         if len(nml2_doc.includes) > 0:
             print_method(
-                "NOT including included files, even though %s are included!"
+                "NOT processing included files, even though %s are included!"
                 % len(nml2_doc.includes),
                 verbose,
             )
-
-        nml2_doc.includes = []
 
     return nml2_doc
 


### PR DESCRIPTION
…` is False

They are not processed, but they are still listed as files that are to be included. This ensures that the model description accurately matches the XML file.