### PR TITLE
test(lengths): remove dot exporter method and pygraphviz dev dep

### DIFF
--- a/neuroml/test/test_cell.py
+++ b/neuroml/test/test_cell.py
@@ -236,8 +236,6 @@ class TestCell(unittest.TestCase):
 
             graph = acell.get_graph()
             print(graph)
-            import networkx as nx
-            nx.nx_agraph.write_dot(graph, "test_graph.dot")
 
     def test_get_distance(self):
         """test distance method

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,4 @@ flake8
 pytest
 numpy
 networkx
-pygraphviz
 black ; python_version >= '3.0'


### PR DESCRIPTION
this is functionality provided by networkx, so folks can install the optional networkx deps if they need to.