### PR TITLE
fix(loader): test for absolute paths in includes

### DIFF
--- a/neuroml/loaders.py
+++ b/neuroml/loaders.py
@@ -336,7 +336,12 @@ def _read_neuroml2(
         )
 
         for include in nml2_doc.includes:
-            incl_loc = os.path.abspath(os.path.join(base_path_to_use, include.href))
+            # if given path exists, use it, otherwise assume its relative to
+            # current directory and try that
+            if os.path.exists(include.href):
+                incl_loc = os.path.abspath(include.href)
+            else:
+                incl_loc = os.path.abspath(os.path.join(base_path_to_use, include.href))
             if incl_loc not in already_included:
                 print_method(
                     "Loading included NeuroML2 file: %s (base: %s, resolved: %s)"


### PR DESCRIPTION
We first check to see if the included path is fine to load, if it is, that's good. If it isn't, we assume it may be relative to the current path (base path) and try that.

Fixes #182