### PR TITLE
feat: remove numpy version fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          - runs-on: macos-latest
-            python-version: "3.8"
           - runs-on: macos-latest
             python-version: "3.9"
           - runs-on: windows-latest

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ install_requires =
     lxml
     six
     networkx
-    numpy<2.0.0
-    tables>=3.3.0
+    numpy
+    tables
     typing; python_version<"3.5"
     natsort
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: OS Independent
     Development Status :: 5 - Production/Stable
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11


### PR DESCRIPTION
Pytables>3.10.1 supports numpy2.x

https://github.com/PyTables/PyTables/releases/tag/v3.10.1