### PR TITLE
Feat: add method to list parameters of a component object

### DIFF
--- a/neuroml/nml/generatedssupersuper.py
+++ b/neuroml/nml/generatedssupersuper.py
@@ -481,9 +481,9 @@ class GeneratedsSuperSuper(object):
         """
         info = self.info(show_contents="all", return_format="dict")
         parameters = {}
-        for member, memberinfo in info.values():
+        for member, memberinfo in info.items():
             if memberinfo["type"].startswith("Nml2Quantity_"):
-                parameters["member"] = memberinfo.members
+                parameters[member] = memberinfo["members"]
 
         return parameters
 

--- a/neuroml/nml/generatedssupersuper.py
+++ b/neuroml/nml/generatedssupersuper.py
@@ -468,6 +468,25 @@ class GeneratedsSuperSuper(object):
             print(info_str)
             return info_str
 
+    def get_parameters(self):
+        """Get parameters for this component
+
+        This returns a subset of the results of the `info()` method, limiting
+        the results to the parameters only.
+
+        :returns: dictionary with parameter names as keys, and parameter values
+            as values
+        :rtype: dict[str, str]
+
+        """
+        info = self.info(show_contents="all", return_format="dict")
+        parameters = {}
+        for member, memberinfo in info.values():
+            if memberinfo["type"].startswith("Nml2Quantity_"):
+                parameters["member"] = memberinfo.members
+
+        return parameters
+
     def validate(self, recursive=False):
         """Validate the component.
 

--- a/neuroml/nml/generatedssupersuper.py
+++ b/neuroml/nml/generatedssupersuper.py
@@ -474,6 +474,8 @@ class GeneratedsSuperSuper(object):
         This returns a subset of the results of the `info()` method, limiting
         the results to the parameters only.
 
+        .. versionadded:: 0.6.6
+
         :returns: dictionary with parameter names as keys, and parameter values
             as values
         :rtype: dict[str, str]

--- a/neuroml/nml/generatedssupersuper.py
+++ b/neuroml/nml/generatedssupersuper.py
@@ -482,7 +482,10 @@ class GeneratedsSuperSuper(object):
         info = self.info(show_contents="all", return_format="dict")
         parameters = {}
         for member, memberinfo in info.items():
-            if memberinfo["type"].startswith("Nml2Quantity_"):
+            if (
+                memberinfo["type"].startswith("Nml2Quantity_")
+                or memberinfo["type"] == "NmlId"
+            ):
                 parameters[member] = memberinfo["members"]
 
         return parameters

--- a/neuroml/test/test_nml.py
+++ b/neuroml/test/test_nml.py
@@ -870,6 +870,21 @@ class TestNML(unittest.TestCase):
         print(annotation_text)
         self.assertEqual("<Annotation>some_string</Annotation>", annotation_text)
 
+    def test_parameter_listing(self):
+        """Test listing component parameters"""
+        cell = component_factory(
+            "IafCell",
+            id="test_cell",
+            thresh="10mV",
+            leak_reversal="10mV",
+            reset="0mV",
+            C="10 F",
+            leak_conductance="10 nS",
+        )  # type: neuroml.Cell
+        # parameters = cell.info(return_format="dict", show_contents="all")
+        parameters = cell.get_parameters()
+        print(parameters)
+
 
 if __name__ == "__main__":
     ta = TestNML()

--- a/neuroml/test/test_nml.py
+++ b/neuroml/test/test_nml.py
@@ -873,15 +873,17 @@ class TestNML(unittest.TestCase):
     def test_parameter_listing(self):
         """Test listing component parameters"""
         params = {
+            "id": "test_cell",
             "thresh": "10mV",
             "leak_reversal": "10mV",
             "reset": "0mV",
             "C": "10 F",
             "leak_conductance": "10 nS",
         }
-        cell = component_factory("IafCell", id="test_cell", **params)  # type: neuroml.Cell
+        cell = component_factory("IafCell", **params)  # type: neuroml.Cell
         received_parameters = cell.get_parameters()
         self.assertDictEqual(params, received_parameters)
+        print(received_parameters)
 
 
 if __name__ == "__main__":

--- a/neuroml/test/test_nml.py
+++ b/neuroml/test/test_nml.py
@@ -872,18 +872,16 @@ class TestNML(unittest.TestCase):
 
     def test_parameter_listing(self):
         """Test listing component parameters"""
-        cell = component_factory(
-            "IafCell",
-            id="test_cell",
-            thresh="10mV",
-            leak_reversal="10mV",
-            reset="0mV",
-            C="10 F",
-            leak_conductance="10 nS",
-        )  # type: neuroml.Cell
-        # parameters = cell.info(return_format="dict", show_contents="all")
-        parameters = cell.get_parameters()
-        print(parameters)
+        params = {
+            "thresh": "10mV",
+            "leak_reversal": "10mV",
+            "reset": "0mV",
+            "C": "10 F",
+            "leak_conductance": "10 nS",
+        }
+        cell = component_factory("IafCell", id="test_cell", **params)  # type: neuroml.Cell
+        received_parameters = cell.get_parameters()
+        self.assertDictEqual(params, received_parameters)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a `get_parameters` function to each nml component type class to get the parameters of the component. We don't use LEMS here, we simply look for any members that have a `NeuroMLQuantity...` type.

Once this is merged, we'll add a `get_model_parameters` utility function to pyNeuroML that users can use to get info on the main bits of a model, eg: cells, synapses, inputs, and so on. 