### PR TITLE
feat: enable 3.14 support + ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - runs-on: macos-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Scientific/Engineering :: Bio-Informatics
     Topic :: Scientific/Engineering
 


### PR DESCRIPTION
tables is now available for 3.14 also:
https://pypi.org/project/tables/#files